### PR TITLE
drop support Python3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 matrix:
   include:
+    - python: 2.7
+      env: TOXENV=py27
     - python: 3.5
       env: TOXENV=py35
     - python: 3.6
@@ -23,8 +25,8 @@ before_install:
   - git submodule update --init
 install:
   - pip install tox
+  - if test "$TOXENV" = py27 ; then pip install --upgrade "pytest<5.0.0"; fi
   - if test "$TOXENV" = py37 ; then pip install coveralls ; fi
-  # - if test "$TOXENV" = py32 ; then pip install --upgrade "virtualenv<14.0.0" "setuptools<30.0.0"; fi
   - python setup.py dataset
 script: 
   - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,6 @@
 language: python
 matrix:
   include:
-    # Drop Support py26
-    # - python: 2.6
-    #   env: TOXENV=py26
-    - python: 2.7
-      env: TOXENV=py27
-    # Drop Support py32
-    # - python: 3.4
-    #   env: TOXENV=py32
-    # tox drop support py33
-    # - python: 3.3
-    #   env: TOXENV=py33
-    - python: 3.4
-      env: TOXENV=py34
     - python: 3.5
       env: TOXENV=py35
     - python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
       env: TOXENV=py37
       dist: xenial
       sudo: true
-    - python: pypy
+    - python: pypy3.5
       env: TOXENV=pypy
     - python: 3.7
       env: TOXENV=flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ before_install:
   - git submodule update --init
 install:
   - pip install tox
-  - if test "$TOXENV" = py27 ; then pip install --upgrade "pytest<5.0.0"; fi
   - if test "$TOXENV" = py37 ; then pip install coveralls ; fi
   - python setup.py dataset
 script: 

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,6 @@ classifiers = [
     "Programming Language :: Python :: 2",
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.3",
-    "Programming Language :: Python :: 3.4",
     "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,10 @@ envlist=py27,py34,py35,py36,py37,pypy,flake8,mypy,autopep8
 commands=
    python setup.py test
 
+[testenv:py27]
+commands=
+   pip install --upgrade "pytest<5.0.0" && python setup.py test
+
 [testenv:flake8]
 deps = flake8
 commands=

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py34,py35,py36,py37,pypy,flake8,mypy,autopep8
+envlist=py27,py35,py36,py37,pypy,flake8,mypy,autopep8
 
 [testenv]
 commands=

--- a/tox.ini
+++ b/tox.ini
@@ -6,9 +6,9 @@ commands=
    python setup.py test
 
 [testenv:py27]
-commands=
-   pip install --upgrade "pytest<5.0.0"
-   python setup.py test
+deps =
+    pytest<5.0.0
+commands = python setup.py test
 
 [testenv:flake8]
 deps = flake8

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,8 @@ commands=
 
 [testenv:py27]
 commands=
-   pip install --upgrade "pytest<5.0.0" && python setup.py test
+   pip install --upgrade "pytest<5.0.0"
+   python setup.py test
 
 [testenv:flake8]
 deps = flake8


### PR DESCRIPTION
## why
In my opinion, basically there is no reason to actively use Python 2.7 and 3.4, and I want to support it because using the latest pytest (version 5.x) also fails the test.

## change summary
* changed to not run python 3.4 tests
* change from PyPy(2.x) to PyPy3.5 on test