### PR TITLE
add Python3.8 test environment on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ matrix:
       env: TOXENV=py36
     - python: 3.7
       env: TOXENV=py37
-      dist: xenial
-      sudo: true
+    - python: 3.8
+      env: TOXENV=py38
     - python: pypy3.5
       env: TOXENV=pypy
     - python: 3.7


### PR DESCRIPTION
https://docs.travis-ci.com/user/languages/python/#specifying-python-versions

for example:
```
language: python
python:
  - "2.7"
  - "3.4"
  - "3.5"
  - "3.6"      # current default Python on Travis CI
  - "3.7"
  - "3.8"
  - "3.8-dev"  # 3.8 development branch
  - "nightly"  # nightly build
# command to install dependencies
install:
  - pip install -r requirements.txt
# command to run tests
script:
  - pytest
```